### PR TITLE
Explicitly add the SmallGrp package as a dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -73,7 +73,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">=4.8",
-  NeededOtherPackages := [],
+  NeededOtherPackages := [["SmallGrp", ">=1.0"]],
   SuggestedOtherPackages := [],
   ExternalConditions := []
 ),

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -294,7 +294,8 @@ function( n, pos_n, m )
 
     # no parent; 
     if d[ 2 ]="G" then # loop of type MG2
-        G := AllSmallGroups( d[ 3 ], IsCommutative, false)[ d[ 4 ] ];  #relies on GAP group libraries !!
+        # AllSmallGroups relies on the SmallGrp package
+        G := AllSmallGroups( d[ 3 ], IsCommutative, false)[ d[ 4 ] ];
         return LoopMG2( G );
     fi;
     if d[ 2 ]="T" then # special loop (direct product of an old loop and a cyclic group)

--- a/gap/random.gi
+++ b/gap/random.gi
@@ -174,6 +174,7 @@ function( lst )
     fi;
     # central subloop
     if IsInt( n ) then # first argument is a positive integer
+        # Uses AllSmallGroups from the SmallGrp package
         K := IntoLoop( Random( AllSmallGroups( n, IsAbelian ) ) );
     else # first argument is an abelian group
         K := IntoLoop( n );


### PR DESCRIPTION
`loops` makes use of the `SmallGrp` function `AllSmallGroups` in two locations in its `.gi` files, so I think it'd just be fair enough to include `SmallGrp` as a dependency.

Note that we'll probably need to do the same for `TransitiveGroup` and `transgrp`.

See https://github.com/gap-system/gap/issues/2434